### PR TITLE
fix(source): Fix linux source bugs

### DIFF
--- a/smart-env.sh
+++ b/smart-env.sh
@@ -6,11 +6,11 @@
 # example: source smart-env.sh aarch64  # aarch64
 
 # supported arch list
-supported_arch="arm aarch64 riscv64 i386"
+supported_arch=(arm aarch64 riscv64 i386)
 
 def_arch="unknown" 
 
-SHELL_FOLDER=$(cd $(dirname ${BASH_SOURCE[0]}); pwd)
+SHELL_FOLDER=$(cd $(dirname $0); pwd)
 
 # find arch in arch list
 if [ -z $1 ]


### PR DESCRIPTION
1. use array to define 'supported_arch'
2. replace $BASH_SOURCE[0] by $0 because some shells don't support such as zsh.