### PR TITLE
Fix the riscv64 config copy issue. 

### DIFF
--- a/smart-env.sh
+++ b/smart-env.sh
@@ -11,7 +11,7 @@ supported_arch="arm aarch64 riscv64"
 
 def_arch="unknown" 
 
-SHELL_FOLDER=$(cd $(dirname $0); pwd)
+SHELL_FOLDER=$(cd $(dirname $BASH_SOURCE); pwd)
 
 # find arch in arch list
 if [ -z $1 ]


### PR DESCRIPTION
With SOURCE command, "dirname $0" can't get the right shell folder, so the riscv64 config won't be copied to .config. It will use default arm toolchain config to compile.
Use $BASH_SOURCE instead of $0 will get the right shell folder.