### PR TITLE
update riscv64/link.lds: update (.text*) (.rodata*) wildcard.

### DIFF
--- a/linker_scripts/riscv64/link.lds
+++ b/linker_scripts/riscv64/link.lds
@@ -23,7 +23,7 @@ SECTIONS
     {
         __text_start__ = .;
         *(.start);
-        *(.text)                        /* remaining code */
+        *(.text*)                        /* remaining code */
 
         KEEP(*(.init))
         KEEP(*(.fini))
@@ -42,7 +42,7 @@ SECTIONS
         *(SORT(.dtors.*))
         *(.dtors)
 
-        *(.rodata)                      /* read-only data (constants) */
+        *(.rodata*)                      /* read-only data (constants) */
         
         KEEP(*(.eh_frame*))
 


### PR DESCRIPTION
未更新前，链接出来的elf文件将会有很多类似`.text.exit` `.text.puts`这样的段。