### PR TITLE
[HUST CSE] Fix: possible absence of va_end after va_start

### DIFF
--- a/apps/webclient/packages/webclient-v2.1.2/src/webclient.c
+++ b/apps/webclient/packages/webclient-v2.1.2/src/webclient.c
@@ -525,6 +525,7 @@ int webclient_header_fields_add(struct webclient_session *session, const char *f
     if (length < 0)
     {
         LOG_E("add fields header data failed, return length(%d) error.", length);
+        va_end(args);
         return -WEBCLIENT_ERROR;
     }
     va_end(args);
@@ -1560,6 +1561,7 @@ int webclient_request_header_add(char **request_header, const char *fmt, ...)
     if (length < 0)
     {
         LOG_E("add request header data failed, return length(%d) error.", length);
+        va_end(args);
         return -WEBCLIENT_ERROR;
     }
     va_end(args);


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

#### 为什么提交这份PR (why to submit this PR)

代码中以函数va_start实现相关功能，但在一些特殊的判断条件下，代码不会调用与之对应的va_end函数，存在潜在的安全隐患。

#### 你的解决方案是什么 (what is your solution)

在对应的判断条件下增加va_end函数，确保va_start与va_end成对出现。

#### 在什么测试环境下测试通过 (what is the test environment)

ALL

]

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x]  本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x]  已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x]  代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x]  没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x]  所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x]  对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x]  代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)