### PR TITLE
fix(repo/packages/m/micropython/xmake.lua): fix building error

### DIFF
--- a/repo/packages/m/micropython/patches/1.20.0/02_fix_gcc13.diff
+++ b/repo/packages/m/micropython/patches/1.20.0/02_fix_gcc13.diff
@@ -1,0 +1,20 @@
+diff --git a/py/stackctrl.c b/py/stackctrl.c
+index c2f3adb5eedc..c2566ebad92b 100644
+--- a/py/stackctrl.c
++++ b/py/stackctrl.c
+@@ -28,8 +28,15 @@
+ #include "py/stackctrl.h"
+ 
+ void mp_stack_ctrl_init(void) {
++    #if __GNUC__ >= 13
++    #pragma GCC diagnostic push
++    #pragma GCC diagnostic ignored "-Wdangling-pointer"
++    #endif
+     volatile int stack_dummy;
+     MP_STATE_THREAD(stack_top) = (char *)&stack_dummy;
++    #if __GNUC__ >= 13
++    #pragma GCC diagnostic pop
++    #endif
+ }
+ 
+ void mp_stack_set_top(void *top) {

--- a/repo/packages/m/micropython/xmake.lua
+++ b/repo/packages/m/micropython/xmake.lua
@@ -32,6 +32,9 @@ do
     add_patches("1.20.0", path.join(os.scriptdir(), "patches", "1.20.0", "01_adapt_smart.diff"),
                 "d0eb05d02339977f9c5771dcc81d2a616962ec57cb4d272fe8da3b8b22cc830c")
 
+    add_patches("1.20.0", path.join(os.scriptdir(), "patches", "1.20.0", "02_fix_gcc13.diff"),
+                "3b9ac8febc3582c8c914c9c8f53340a78b417c7d707aafd8c63585b34fa55454")
+
     add_configs("shared", {
         description = "Build shared library.",
         default = os.getenv("RT_XMAKE_LINK_TYPE") ~= "static",


### PR DESCRIPTION
Error occurs when compiling with
new toolchain. Apply the upstream
patch so it compiles fine.

ref:
https://github.com/orgs/micropython/discussions/12027
https://groups.google.com/g/linux.debian.bugs.dist/c/7STyhQksi5o