### PR TITLE
[rt_utils] 修改 cp_with_symlink

### DIFF
--- a/tools/scripts/modules/rt/rt_utils.lua
+++ b/tools/scripts/modules/rt/rt_utils.lua
@@ -73,8 +73,12 @@ function cp_with_symlink(srcpath, dstpath, opt)
     else
         option = opt or {symlink = true}
     end
-    os.tryrm(dstpath)
-    os.vcp(srcpath, dstpath, option)
+    if (opt and opt.del == false) then
+        os.execv("cp -r", {srcpath, dstpath})
+    else
+        os.tryrm(dstpath)
+        os.vcp(srcpath, dstpath, option)
+    end
 end
 
 function dirsize(dir)


### PR DESCRIPTION
添加了不删除源文件夹选项，因为不同安装包安装时有向同一个文件夹中安装文件的现象发生