### PR TITLE
feat: default to build dynamic APPs

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -3,7 +3,7 @@
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 export XMAKE_RCFILES=${script_dir}/tools/scripts/xmake.lua
-export RT_XMAKE_LINK_TYPE="static"
+export RT_XMAKE_LINK_TYPE="shared"
 
 
 # Check whether unzip is installed.


### PR DESCRIPTION
There are several reasons to build dynamic APP as a default:

1. For saving more storage on the target platform.
2. All mainline platforms of RT-Thread Smart support libc.so, making it painless to do so.